### PR TITLE
link opens in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm run package
   - [ ] change intro page (when user has not added any mailbox) to a "empty" page (Peng)
     - [ ] ask for new mailbox if there isn't one already
     - [ ] ask for openai api key if it is not already set
-  - [ ] migrate all `<Link>`s to open in an external browser
+  - [x] migrate all `<Link>`s to open in an external browser
 - [ ] UI improvement
   - [ ] "n more" display (Dongming, Peng)
     - [ ] set the left bar of the calendar page to be fixed

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -1,3 +1,4 @@
+import { shell } from "electron";
 import { addEventsInDB, getMailboxInfoFromDB } from "./data/main";
 import { addRow, deleteRows, query, updateValue } from "./data/utils";
 import { retrieveEmails } from "./email/main";
@@ -138,4 +139,8 @@ export async function handleUpdateMailbox(
     console.log(e);
     return e.message;
   }
+}
+
+export function handleOpenURLInBrowser(url: string): void {
+  shell.openExternal(url);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   handleAddMailbox,
   handleGetEvents,
   handleGetMailboxes,
+  handleOpenURLInBrowser,
   handleRemoveMailbox,
   handleUpdateEvents,
   handleUpdateMailbox,
@@ -67,6 +68,9 @@ app.on("ready", () => {
   });
   ipcMain.handle("verify:imap", (event, ...args) => {
     return handleVerifyIMAP(args[0], args[1]);
+  });
+  ipcMain.handle("browser:open", (event, ...args) => {
+    return handleOpenURLInBrowser(args[0]);
   });
 });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -21,4 +21,5 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("verify:outlook", address),
   verify_imap: (address: string, credentials: StringMap) =>
     ipcRenderer.invoke("verify:imap", address, credentials),
+  browser_open: (url: string) => ipcRenderer.invoke("browser:open", url),
 });

--- a/src/renderer/components/modules/Calendar.tsx
+++ b/src/renderer/components/modules/Calendar.tsx
@@ -95,7 +95,14 @@ const EventPopupDisplay = ({ event }: { event: { [key: string]: string } }) => {
       place = [
         ...place,
         <span key={i}> {venue.substring(lastIndex, index)} </span>,
-        <Link href={url} color="inherit" key={i + 1}>
+        <Link
+          component="button"
+          onClick={() => {
+            window.electronAPI.browser_open(url);
+          }}
+          color="inherit"
+          key={i + 1}
+        >
           URL Link
         </Link>,
       ];
@@ -402,13 +409,14 @@ const Calendar = (props: calendarProps) => {
   return (
     // calendar window(head + calendar)
     // XPath: /html/body/div/div/main/div/div[2]/div
-    <Box 
-      sx={{ 
+    <Box
+      sx={{
         display: "flex",
         flexDirection: "column",
         width: "100%",
         height: "100%",
-    }}>
+      }}
+    >
       <HeaderToolBar calendarRef={calendarRef} setQuery={setQuery} />
       <FullCalendar
         ref={calendarRef}

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -23,6 +23,7 @@ export interface IElectronAPI {
     address: string,
     credentials: StringMap
   ) => Promise<VerifyResposne>;
+  browser_open: (url: string) => Promise<void>;
 }
 
 declare global {


### PR DESCRIPTION
Add an API endpoint to open URL in external browsers. This is intended for old `link` components. All links have been migrated to use the new API.