### PR TITLE
Add a settings section for API key

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,5 +1,20 @@
 # SQLite3 Database Schema
 
+## Settings
+
+| attribute | type   | constraints       |
+| --------- | ------ | ----------------- |
+| key (PK)  | string | not null & unique |
+| value     | string |                   |
+
+`Settings` is a key-value table with pre-defined keys. API calls should not attempt to add any new keys or delete any existing keys.
+
+Pre-defined keys and default values:
+
+```yaml
+- apiKey: ""
+```
+
 ## Mailboxes
 
 | attribute    | type      | constraints       |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "electron-learning",
-  "version": "1.0.0",
+  "name": "wizard",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "electron-learning",
-      "version": "1.0.0",
+      "name": "wizard",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^2.5.1",
@@ -19,7 +19,7 @@
         "@babel/preset-stage-0": "^7.8.3",
         "@types/node": "^20.8.10",
         "babel-loader": "^8.2.2",
-        "better-sqlite3": "^9.2.0",
+        "better-sqlite3": "^9.2.2",
         "concurrently": "^8.2.2",
         "css-loader": "^5.0.1",
         "electron": "^27.1.0",
@@ -4949,9 +4949,9 @@
       "dev": true
     },
     "node_modules/better-sqlite3": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmmirror.com/better-sqlite3/-/better-sqlite3-9.2.0.tgz",
-      "integrity": "sha512-MEm49nfxCU6Yn5rTyXJhnTmjuom0YFrU76/7AC+7PMcftAwIVJ2VtBF6HSPRwQ/WWXw/sSbnPRPUSZ6vMXMniQ==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmmirror.com/better-sqlite3/-/better-sqlite3-9.2.2.tgz",
+      "integrity": "sha512-qwjWB46il0lsDkeB4rSRI96HyDQr8sxeu1MkBVLMrwusq1KRu4Bpt1TMI+8zIJkDUtZ3umjAkaEjIlokZKWCQw==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@babel/preset-stage-0": "^7.8.3",
     "@types/node": "^20.8.10",
     "babel-loader": "^8.2.2",
-    "better-sqlite3": "^9.2.0",
+    "better-sqlite3": "^9.2.2",
     "concurrently": "^8.2.2",
     "css-loader": "^5.0.1",
     "electron": "^27.1.0",

--- a/src/api/data/init.ts
+++ b/src/api/data/init.ts
@@ -12,6 +12,22 @@ export function initDatabase(redo: boolean = false): void {
   // Connect to the SQLite database
   const db = new Database("app.db");
 
+  // create settings table
+  const createSettingsTable = db.prepare(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY NOT NULL UNIQUE,
+      value TEXT NOT NULL
+    )
+  `);
+  createSettingsTable.run();
+
+  // Create default settings
+  const insertDefaultSettings = db.prepare(`
+    INSERT INTO settings (key, value)
+    VALUES (?, ?)
+  `);
+  insertDefaultSettings.run("apiKey", "");
+
   // Create Mailboxes table
   const createMailboxesTable = db.prepare(`
     CREATE TABLE IF NOT EXISTS mailboxes (

--- a/src/api/data/init.ts
+++ b/src/api/data/init.ts
@@ -6,7 +6,10 @@ import * as fs from "fs";
  * @param redo whether to re-initialize the database if it already exists. Defaults to false.
  */
 export function initDatabase(redo: boolean = false): void {
-  if (redo && fs.existsSync("app.db")) {
+  if (fs.existsSync("app.db")) {
+    if (!redo) {
+      return;
+    }
     fs.unlinkSync("app.db");
   }
   // Connect to the SQLite database

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -59,6 +59,9 @@ export async function handleUpdateEvents(
         if (result.length > 0) {
           return;
         }
+        console.log(`parsing email: ${id}, address: ${address}`);
+        let events = await parseEmail(email, await getApiKey(), 5, kwargs);
+        console.log(`storing ${events.length} events for email: ${id}`);
         addRow(
           {
             email_id: id,
@@ -67,9 +70,6 @@ export async function handleUpdateEvents(
           },
           "emails"
         );
-        console.log(`parsing email: ${id}, address: ${address}`);
-        let events = await parseEmail(email, await getApiKey(), 5, kwargs);
-        console.log(`storing ${events.length} events for email: ${id}`);
         await addEventsInDB(events, id, address);
       })
     );

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -158,3 +158,15 @@ export async function handleUpdateMailbox(
 export function handleOpenURLInBrowser(url: string): void {
   shell.openExternal(url);
 }
+
+export async function handleUpdateSettings(req: StringMap): Promise<string> {
+  try {
+    for (let key in req) {
+      updateValue("value", req[key], { key: key }, "settings");
+    }
+    return "";
+  } catch (e) {
+    console.log(e);
+    return e.message;
+  }
+}

--- a/src/api/parse/main.ts
+++ b/src/api/parse/main.ts
@@ -11,6 +11,7 @@ export async function parseEmail(
   kwargs: StringMap
 ): Promise<StringMap[]> {
   let prompt = getPrompt(email, kwargs);
+  let error = null;
   for (let i = 0; i < maxPatience; i++) {
     try {
       let rawResult = await getLLMResponse(prompt, apiKey);
@@ -19,8 +20,8 @@ export async function parseEmail(
     } catch (err) {
       console.log("Error when parsing email: " + err.toString());
       await new Promise((resolve) => setTimeout(resolve, 1000));
+      error = err;
     }
   }
-
-  return [];
+  throw error;
 }

--- a/src/api/tests/test.ts
+++ b/src/api/tests/test.ts
@@ -23,14 +23,14 @@ async function testMailbox(): Promise<void> {
 
 async function testEvents(): Promise<void> {
   await prepareTestDatabase();
-  let errMsg = await handleUpdateEvents("example@gmail.com");
-  if (errMsg != "") {
-    console.log(errMsg);
+  let resp = await handleUpdateEvents("example@gmail.com");
+  if (resp.retrievalErrorMsg != "" || resp.parseErrorMsg != "") {
+    console.log(resp);
   }
   console.log(await handleGetEvents());
   await handleRemoveMailbox("example@gmail.com");
   console.log(await handleGetEvents());
 }
 
-testMailbox();
-// testEvents();
+// testMailbox();
+testEvents();

--- a/src/api/tests/testSettings.ts
+++ b/src/api/tests/testSettings.ts
@@ -1,0 +1,29 @@
+import { initDatabase } from "../data/init";
+import { query, updateValue } from "../data/utils";
+import { handleUpdateSettings } from "../main";
+
+async function testReadInitSettings(): Promise<void> {
+  initDatabase(true);
+  let data = query(["*"], {}, "settings");
+  console.log(data);
+}
+
+async function testUpdateSettings(): Promise<void> {
+  initDatabase(true);
+  let errMsg = handleUpdateSettings({ apiKey: "1234" });
+  console.log(errMsg);
+  let data = query(["*"], {}, "settings");
+  console.log(data);
+}
+
+async function testUpdateNewKeySettings(): Promise<void> {
+  initDatabase(true);
+  let errMsg = await handleUpdateSettings({ newKey: "1234" });
+  console.log(errMsg);
+  let data = query(["*"], {}, "settings");
+  console.log(data);
+}
+
+// testReadInitSettings();
+// testUpdateSettings();
+testUpdateNewKeySettings();

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,4 +1,5 @@
 import { getMailboxInfoFromDB } from "./data/main";
+import { query } from "./data/utils";
 import {
   refreshGmailCredentials,
   revokeGmailCredentials,
@@ -6,11 +7,8 @@ import {
 import { refreshOutlookCredentials } from "./mailbox/outlook";
 
 export async function getApiKey(): Promise<string> {
-  let key = process.env.OPENAI_API_KEY || "";
-  if (key === "") {
-    throw new Error("OPENAI_API_KEY is not set");
-  }
-  return key;
+  let data = query(["value"], { key: "apiKey" }, "settings");
+  return data[0].value;
 }
 
 export async function refreshCredentialsIfExpire(address: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   handleRemoveMailbox,
   handleUpdateEvents,
   handleUpdateMailbox,
+  handleUpdateSettings,
 } from "./api/main";
 import { initDatabase } from "./api/data/init";
 import { handleVerifyGmail } from "./api/mailbox/gmail";
@@ -71,6 +72,9 @@ app.on("ready", () => {
   });
   ipcMain.handle("browser:open", (event, ...args) => {
     return handleOpenURLInBrowser(args[0]);
+  });
+  ipcMain.handle("settings:put", (event, ...args) => {
+    return handleUpdateSettings(args[0]);
   });
 });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -22,4 +22,5 @@ contextBridge.exposeInMainWorld("electronAPI", {
   verify_imap: (address: string, credentials: StringMap) =>
     ipcRenderer.invoke("verify:imap", address, credentials),
   browser_open: (url: string) => ipcRenderer.invoke("browser:open", url),
+  update_settings: (req: StringMap) => ipcRenderer.invoke("settings:put", req),
 });

--- a/src/renderer/components/modules/Feed.tsx
+++ b/src/renderer/components/modules/Feed.tsx
@@ -1,15 +1,21 @@
-import React, { useState } from "react";
+import React from "react";
 import Calendar from "./Calendar";
 import { userInfoType } from "./SideBar";
 import { Box } from "@mui/material";
+import Alert from "@mui/material/Alert";
 
 type FeedProps = {
   userInfo: userInfoType | undefined;
   toGetUserEvents: boolean;
+  appErrMsg: string;
   setErrorMailboxes: (addresses: string[]) => void;
+  setAppErrMsg: (msg: string) => void;
 };
 
 const Feed = (props: FeedProps) => {
+  // useEffect(() => {
+  //   props.setAppErrMsg("something wrong with the app");
+  // }, []);
   return (
     <Box
       sx={{
@@ -17,16 +23,36 @@ const Feed = (props: FeedProps) => {
         height: "100%",
         boxSizing: "border-box",
         overflow: "hidden",
+        display: "flex",
+        flexDirection: "column",
       }}
       pb="3%"
       pr="3%"
       pl="3%"
-      pt={3}
+      pt={props.appErrMsg !== "" ? 1 : 3}
     >
+      {props.appErrMsg !== "" ? (
+        <Alert
+          severity="warning"
+          sx={{
+            mb: 1,
+            flex: "0 0 auto",
+          }}
+          onClose={() => {
+            console.log("setting appErrMsg to empty");
+            props.setAppErrMsg("");
+          }}
+        >
+          {props.appErrMsg}
+        </Alert>
+      ) : (
+        <></>
+      )}
       <Calendar
         userInfo={props.userInfo}
         setErrorMailboxes={props.setErrorMailboxes}
         toGetUserEvents={props.toGetUserEvents}
+        setAppErrMsg={props.setAppErrMsg}
       />
     </Box>
   );

--- a/src/renderer/components/modules/SettingsWindow.tsx
+++ b/src/renderer/components/modules/SettingsWindow.tsx
@@ -1,0 +1,161 @@
+import React, { useState } from "react";
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Container,
+  CssBaseline,
+  TextField,
+  Typography,
+} from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
+import SettingsSharpIcon from "@mui/icons-material/SettingsSharp";
+
+const updateSettings = async (req: { apiKey: string }): Promise<string> => {
+  try {
+    let errMsg = await window.electronAPI.update_settings(req);
+    return errMsg;
+  } catch (e) {
+    console.log("caught error when updating settings:", e);
+    return "fail to update settings.";
+  }
+};
+
+const SettingsWindow = (props: {
+  setOpenSettings: (b: boolean) => void;
+  callGetUserEvents: () => void;
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const handleSubmit = (event: any) => {
+    setLoading(true);
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    let req = {
+      apiKey: data.get("apiKey") as string,
+    };
+    console.log(req);
+    updateSettings(req)
+      .then((errMsg) => {
+        setLoading(false);
+        if (errMsg === "") {
+          props.callGetUserEvents();
+          props.setOpenSettings(false);
+        } else {
+          console.log("error when adding mailbox:", errMsg);
+          setErrorMsg(errMsg);
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+        zIndex: 1,
+      }}
+    >
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="100vh"
+      >
+        <Container
+          maxWidth="xs"
+          fixed
+          sx={{
+            bgcolor: "common.white",
+            pt: 1.5,
+          }}
+        >
+          <CssBaseline />
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+            }}
+          >
+            <Avatar sx={{ m: 1, bgcolor: "secondary.main" }}>
+              <SettingsSharpIcon />
+            </Avatar>
+            <Typography component="h1" variant="h5">
+              Settings
+            </Typography>
+            <Box
+              component="form"
+              onSubmit={handleSubmit}
+              // noValidate
+              sx={{ mt: 2, width: "80%" }}
+            >
+              {errorMsg === "" ? (
+                <></>
+              ) : (
+                <Alert
+                  severity="error"
+                  sx={{
+                    mb: 2,
+                  }}
+                >
+                  {errorMsg}
+                </Alert>
+              )}
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                id="apiKey"
+                label="OpenAI API Key"
+                name="apiKey"
+                autoComplete="john@example.com"
+                autoFocus
+              />
+
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  m: 1,
+                }}
+              >
+                <LoadingButton
+                  type="submit"
+                  variant="contained"
+                  color="secondary"
+                  sx={{ m: 1 }}
+                  loading={loading}
+                >
+                  Submit
+                </LoadingButton>
+                <Button
+                  variant="text"
+                  color="secondary"
+                  sx={{ m: 1 }}
+                  onClick={() => {
+                    props.setOpenSettings(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </Box>
+            </Box>
+          </Box>
+        </Container>
+      </Box>
+    </Box>
+  );
+};
+
+export default SettingsWindow;

--- a/src/renderer/components/modules/SideBar.tsx
+++ b/src/renderer/components/modules/SideBar.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
 import UserAccountInfo from "./UserAccountInfo";
 import { useNavigate } from "react-router-dom";
-import { Box, Button } from "@mui/material";
+import { Box, Button, IconButton, Typography } from "@mui/material";
+import SettingsSharpIcon from "@mui/icons-material/SettingsSharp";
 
 type userInfoType = {
   useraccounts: { address: string; protocol: string }[];
@@ -15,6 +16,7 @@ type SideBarProps = {
   setAddAccount: (status: boolean) => void;
   setDeleteAccount: (mailbox: string) => void;
   setUpdateAccount: (mailbox: { address: string; protocol: string }) => void;
+  setOpenSettings: (status: boolean) => void;
   setAppErrMsg: (msg: string) => void;
 };
 
@@ -74,6 +76,9 @@ const SideBar = (props: SideBarProps) => {
         bgcolor: "primary.main",
         width: "20vw",
         // overflow: "scroll",
+        display: "flex",
+        flexDirection: "column",
+        pb: 2,
       }}
     >
       <UserAccountInfo
@@ -87,6 +92,58 @@ const SideBar = (props: SideBarProps) => {
         setUpdateAccount={props.setUpdateAccount}
         errorMailboxes={props.errorMailboxes}
       />
+      <SettingsTab setOpenSettings={props.setOpenSettings} />
+    </Box>
+  );
+};
+
+const SettingsTab = (props: { setOpenSettings: (status: boolean) => void }) => {
+  return (
+    <Box
+      sx={{
+        "&:hover": {
+          backgroundColor: "primary.dark",
+          opacity: [0.9, 0.8, 0.7],
+          cursor: "default",
+        },
+        width: "100%",
+        pl: "10%",
+        pr: "5%",
+        boxSizing: "border-box",
+        color: "common.white",
+      }}
+    >
+      <IconButton
+        onClick={() => {
+          props.setOpenSettings(true);
+        }}
+        sx={{
+          color: "inherit",
+          pl: 0,
+          pb: 1,
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          <SettingsSharpIcon color="inherit"></SettingsSharpIcon>
+          <Typography
+            color="inherit"
+            sx={{
+              width: "100%",
+              fontWeight: "bold",
+              ml: 0.5,
+            }}
+            noWrap
+            // gutterBottom
+          >
+            Settings
+          </Typography>
+        </Box>
+      </IconButton>
     </Box>
   );
 };

--- a/src/renderer/components/modules/SideBar.tsx
+++ b/src/renderer/components/modules/SideBar.tsx
@@ -15,6 +15,7 @@ type SideBarProps = {
   setAddAccount: (status: boolean) => void;
   setDeleteAccount: (mailbox: string) => void;
   setUpdateAccount: (mailbox: { address: string; protocol: string }) => void;
+  setAppErrMsg: (msg: string) => void;
 };
 
 const getUserInfoAPI = async (): Promise<{

--- a/src/renderer/components/modules/UserAccountInfo.tsx
+++ b/src/renderer/components/modules/UserAccountInfo.tsx
@@ -119,6 +119,7 @@ const UserAccountInfo = (props: UserAccountInfoProps) => {
         color: "common.white",
         mt: 3,
         width: "100%",
+        flex: 1,
       }}
     >
       <Grid

--- a/src/renderer/components/pages/CalendarPage.tsx
+++ b/src/renderer/components/pages/CalendarPage.tsx
@@ -22,6 +22,7 @@ const CalendarPage = () => {
   });
   const [userInfo, setUserInfo] = useState<userInfoType>();
   const [errorMailboxes, setErrorMailboxes] = useState<string[]>([]);
+  const [appErrMsg, setAppErrMsg] = useState("");
 
   const [toGetUserInfo, setToGetUserInfo] = useState(false);
   const [toGetUserEvents, setToGetUserEvents] = useState(false);
@@ -69,11 +70,14 @@ const CalendarPage = () => {
           setUpdateAccount={setUpdateAccount}
           toGetUserInfo={toGetUserInfo}
           errorMailboxes={errorMailboxes}
+          setAppErrMsg={setAppErrMsg}
         />
         <Feed
           userInfo={userInfo}
           setErrorMailboxes={setErrorMailboxes}
           toGetUserEvents={toGetUserEvents}
+          appErrMsg={appErrMsg}
+          setAppErrMsg={setAppErrMsg}
         />
       </Box>
       {addAccount ? (

--- a/src/renderer/components/pages/CalendarPage.tsx
+++ b/src/renderer/components/pages/CalendarPage.tsx
@@ -6,12 +6,14 @@ import { useNavigate } from "react-router-dom";
 import { Box, Container } from "@mui/material";
 import DeleteAccountConfirmWindow from "../modules/DeleteAccountWindow";
 import UpdateAccountWindow from "../modules/UpdateAccountWindow";
+import SettingsWindow from "../modules/SettingsWindow";
 
 /**
  * Define the "CalendarPage" component as a function.
  */
 const CalendarPage = () => {
   const [addAccount, setAddAccount] = useState(false);
+  const [openSettings, setOpenSettings] = useState(false);
   const [deleteAccount, setDeleteAccount] = useState("");
   const [updateAccount, setUpdateAccount] = useState<{
     address: string;
@@ -68,6 +70,7 @@ const CalendarPage = () => {
           setAddAccount={setAddAccount}
           setDeleteAccount={setDeleteAccount}
           setUpdateAccount={setUpdateAccount}
+          setOpenSettings={setOpenSettings}
           toGetUserInfo={toGetUserInfo}
           errorMailboxes={errorMailboxes}
           setAppErrMsg={setAppErrMsg}
@@ -105,6 +108,14 @@ const CalendarPage = () => {
           setUpdateAccount={setUpdateAccount}
           callGetUserEvents={callGetUserEvents}
           removeMailboxFromError={removeMailboxFromError}
+        />
+      ) : (
+        <></>
+      )}
+      {openSettings ? (
+        <SettingsWindow
+          setOpenSettings={setOpenSettings}
+          callGetUserEvents={callGetUserEvents}
         />
       ) : (
         <></>

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -32,6 +32,7 @@ export interface IElectronAPI {
     credentials: StringMap
   ) => Promise<VerifyResposne>;
   browser_open: (url: string) => Promise<void>;
+  update_settings: (req: StringMap) => Promise<string>;
 }
 
 declare global {

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -6,9 +6,17 @@ type VerifyResposne = {
   credentials: { [key: string]: string };
 };
 
+type UpdateEventsResponse = {
+  retrievalErrorMsg: string;
+  parseErrorMsg: string;
+};
+
 export interface IElectronAPI {
   get_events: () => Promise<StringMap[] | StringKeyMap>;
-  update_events: (address: string, kwargs: StringMap) => Promise<string>;
+  update_events: (
+    address: string,
+    kwargs: StringMap
+  ) => Promise<UpdateEventsResponse>;
   get_mailboxes: () => Promise<StringMap[] | StringKeyMap>;
   add_mailbox: (
     type: string,
@@ -36,5 +44,9 @@ declare global {
   type VerifyResposne = {
     errMsg: string;
     credentials: StringKeyMap;
+  };
+  type UpdateEventsResponse = {
+    retrievalErrorMsg: string;
+    parseErrorMsg: string;
   };
 }


### PR DESCRIPTION
In this PR, retrieval errors and parsing errors are distinguished and displayed to users with instructions on how to solve them. A separate settings section is added to hold user configurations. Currently, user configurations only contains one field: OpenAI api key.