### PR TITLE
Try to parse emails that cannot be successfully parsed before

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -58,6 +58,10 @@ When the `last_email_info` field is not supplied in the time adding a new mailbo
 | email ID (PK)          | string                   | not null    |
 | email address (PK, FK) | string                   | not null    |
 | event IDs              | array of int (JSON text) | -           |
+| parsed                 | integer of boolean       | not null    |
+| email content          | JSON text                | -           |
+
+`email_content` is the JSON string of what returned by the email parsing module.
 
 ## Events
 

--- a/src/api/data/init.ts
+++ b/src/api/data/init.ts
@@ -60,6 +60,8 @@ export function initDatabase(redo: boolean = false): void {
       email_id TEXT NOT NULL,
       email_address TEXT NOT NULL,
       event_ids TEXT NOT NULL,
+      parsed INTEGER NOT NULL,
+      email_content TEXT,
       PRIMARY KEY (email_id, email_address),
       FOREIGN KEY (email_address) REFERENCES mailboxes(address)
     )

--- a/src/api/email/tests/test.ts
+++ b/src/api/email/tests/test.ts
@@ -3,6 +3,7 @@ import { countNewMailSinceTime, retrieveEmails } from "../main";
 import { shiftTimeBySeconds } from "../utils";
 
 const TOKEN_PATH = "token.json";
+const IMAP_PATH = "configs/test_imap.json";
 
 async function test(): Promise<void> {
   const token = fs.readFileSync(TOKEN_PATH);
@@ -10,6 +11,20 @@ async function test(): Promise<void> {
     "doesnotmatter@gmail.com",
     "gmail",
     JSON.parse(token.toString()),
+    10
+  );
+  for (const [id, email] of emails) {
+    console.log("email id: ", id);
+    console.log(email);
+  }
+}
+
+async function testIMAP(): Promise<void> {
+  const token = JSON.parse(fs.readFileSync(IMAP_PATH).toString());
+  const emails = await retrieveEmails(
+    token.username,
+    token.protocol,
+    token.credentials,
     10
   );
   for (const [id, email] of emails) {
@@ -29,4 +44,5 @@ async function testCountTime() {
   console.log(n);
 }
 
-testCountTime();
+// testCountTime();
+testIMAP();


### PR DESCRIPTION
This PR adds a flag per email in the DB to indicate whether it has been successfully parsed. If not, the email content will also be in the DB. In the next parse, the app will first try to parse the failed emails before trying to read and parse new emails.

This PR should close #9.